### PR TITLE
Add `display` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ A JupyterLab and Jupyter Notebook extension for rendering Plotly charts
 To render Plotly JSON using IPython:
 
 ```python
-from IPython.display import display
-import json
+from jupyterlab_plotly import Plotly
 
 data = [
     {'x': [1999, 2000, 2001, 2002], 'y': [10, 15, 13, 17], 'type': 'scatter'},
@@ -29,19 +28,7 @@ layout = {
     'yaxis': { 'title': 'Percent', 'showline': False }
 }
 
-bundle = {
-    'application/vnd.plotly.v1+json': {
-        'data': data,
-        'layout': data,
-    },
-    'application/json': {
-        'data': data,
-        'layout': layout,
-    },
-    'text/plain': '<IPython.core.display.JSON.object>'
-}
-
-display(bundle, raw=True)
+Plotly(data, layout)
 ```
 
 ## Install

--- a/jupyterlab_plotly/__init__.py
+++ b/jupyterlab_plotly/__init__.py
@@ -1,6 +1,9 @@
+from IPython.display import display
+import json
+
+
 # Running `npm run build` will create static resources in the static
 # directory of this Python package (and create that directory if necessary).
-
 
 def _jupyter_labextension_paths():
     return [{
@@ -15,3 +18,22 @@ def _jupyter_nbextension_paths():
         'dest': 'jupyterlab_plotly',
         'require': 'jupyterlab_plotly/extension'
     }]
+
+
+# A display function that can be used within a notebook. E.g.:
+#   from jupyterlab_plotly import Plotly
+#   Plotly(data, layout)
+
+def Plotly(data, layout):
+    bundle = {
+        'application/vnd.plotly.v1+json': {
+            'data': data,
+            'layout': layout,
+        },
+        'application/json': {
+            'data': data,
+            'layout': layout,
+        },
+        'text/plain': '<jupyterlab_plotly.Plotly object>'
+    }
+    display(bundle, raw=True)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup_args = dict(
     keywords             = ['jupyter', 'jupyterlab', 'labextension', 'notebook', 'nbextension'],
     include_package_data = True,
     install_requires = [
-        'jupyterlab>=0.8.0',
+        'jupyterlab>=0.11.0',
+        'ipython>=1.0.0'
     ]
 )
 


### PR DESCRIPTION
Provides a `display` method that can be imported into a notebook:

```py
from jupyterlab_plotly import Plotly

data = [
  {'x': [1999, 2000, 2001, 2002], 'y': [10, 15, 13, 17], 'type': 'scatter'},
  {'x': [1999, 2000, 2001, 2002], 'y': [16, 5, 11, 9], 'type': 'scatter'}
]

layout = {
  'title': 'Sales Growth',
  'xaxis': { 'title': 'Year', 'showgrid': False, 'zeroline': False },
  'yaxis': { 'title': 'Percent', 'showline': False }
}

Plotly(data, layout)
```